### PR TITLE
Git clone을 통해 직접 설치할 때 data/templates 가 누락되는 이슈 해결

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,9 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url='https://github.com/lovit/customized_konlpy',
     packages=setuptools.find_packages(),
-    package_data={'ckonlpy':['data/*/*.txt', 'data/*/*/*.txt']},
+    package_data={
+        'ckonlpy':['data/*/*.txt', 'data/*/*/*.txt', 'data/templates/*']
+    },
     install_requires=["Jpype1>=0.6.1", "konlpy>=0.4.4"],
     classifiers=(
         "Programming Language :: Python :: 3.6",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7248836/43442986-9d041cb6-94da-11e8-94db-23bcf996e333.png)

* package_data에 twitter template이 누락되어서 생긴 문제
* github으로 직접 설치(setup.py or git+https) 할 때 twitter template이 패키지에 설치 안되는 이슈 해결

